### PR TITLE
prompt user on non-whitelisted hosts 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "tokio",
  "u2fframing",
  "warp",
+ "webbrowser",
  "windows-service",
 ]
 
@@ -165,6 +166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -205,6 +215,12 @@ name = "cc"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -284,6 +300,26 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes 1.4.0",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -617,6 +653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +854,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if 1.0.0",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +975,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "num-traits"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +997,40 @@ checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1742,6 +1849,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
+dependencies = [
+ "block2",
+ "core-foundation",
+ "home",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,6 +1935,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -1814,6 +1958,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1849,6 +2008,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
@@ -1861,6 +2026,12 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
@@ -1870,6 +2041,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1891,6 +2068,12 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
@@ -1900,6 +2083,12 @@ name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1915,6 +2104,12 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
@@ -1924,6 +2119,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "u2fframing",
+ "uuid",
  "warp",
  "webbrowser",
  "windows-service",
@@ -1731,6 +1732,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "version_check"

--- a/bitbox-bridge/Cargo.toml
+++ b/bitbox-bridge/Cargo.toml
@@ -20,6 +20,7 @@ windows-service = "0.7.0"
 clap = { version = "4.5", features = ["cargo"] }
 warp = "0.3.7"
 tera = "1.20"
+uuid = { version = "1.10.0", features = ["v4"] }
 
 [dependencies.u2fframing]
 version = "0.1"

--- a/bitbox-bridge/Cargo.toml
+++ b/bitbox-bridge/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+webbrowser = "1.0"
 env_logger = "0.11"
 futures =  { workspace = true }
 futures-util = { workspace = true }

--- a/bitbox-bridge/resources/confirmation_dialog.html
+++ b/bitbox-bridge/resources/confirmation_dialog.html
@@ -111,7 +111,7 @@
     </div>
     <script>
         function sendResponse(userChoice) {
-            fetch(`/confirm/response/{{ counter }}/${userChoice}`, { method: 'POST' })
+            fetch(`/confirm/response/{{ confirm_id }}/${userChoice}`, { method: 'POST' })
                 .then(() => window.close())
                 .catch(err => console.error('Error sending response:', err));
         }

--- a/bitbox-bridge/resources/confirmation_dialog.html
+++ b/bitbox-bridge/resources/confirmation_dialog.html
@@ -3,12 +3,112 @@
 <head>
     <meta charset="UTF-8">
     <title>BitBoxBridge</title>
+    <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+        }
+        body {
+            align-items: center;
+            background-color: #f5f5f5;
+            display: flex;
+            justify-content: center;
+            overflow-y: auto;
+        }
+        body, button {
+            font-family: sans-serif;
+            color: #333;
+        }
+        .container {
+            background-color: #fff;
+            border-radius: 2px;
+            /* box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); */
+            box-sizing: border-box;
+            display: block;
+            max-width: 640px;
+            min-height: 360px;
+            padding: 20px 30px;
+            text-align: center;
+            width: 100%;
+        }
+        .dbb-logo {
+            width: 72px;
+            height: 100%;
+            margin-top: 16px;
+            padding: 0.3em;
+        }
+        h1 {
+            font-size: 32px;
+            line-height: 1.25;
+            margin-top: 0;
+        }
+        p {
+            line-height: 1.4;
+            margin-bottom: 48px;
+        }
+        button {
+            background-color: #fff;
+            border: 2px solid #6b9ec5;
+            border-radius: 2px;
+            cursor: pointer;
+            display: inline-block;
+            font-size: 16px;
+            height: 48px;
+            letter-spacing: 0.2px;
+            line-height: 46px;
+            margin: 0 0 16px 0;
+            min-width: 165px;
+            padding: 0 8px;
+        }
+        button + button {
+            margin-left: 16px;
+        }
+        button:hover {
+            border-color: #5794c4;
+        }
+        button svg {
+            display: inline;
+            margin-right: 8px;
+            max-height: 26px;
+            max-width: 26px;
+            vertical-align: middle;
+        }
+        .agree {
+            border-color: #78bd77;
+        }
+        .decline {
+            border-color: #ec644b;
+        }
+    </style>
 </head>
 <body>
-    <h1>BitBoxBridge</h1>
-    <p>{{ message }}</p>
-    <button onclick="sendResponse(false)">Reject</button>
-    <button onclick="sendResponse(true)">Accept</button>
+
+    <span hidden>
+        <svg xmlns="http://www.w3.org/2000/svg">
+        <symbol id="checkmark" class="checkmark" viewBox="0 0 52 52" stroke-linecap="round" stroke-linejoin="round" stroke-width="6">
+            <circle cx="26" cy="26" r="26" fill="#78bd77"/>
+            <path d="M14.1 27.2l7.1 7.2 16.7-16.8" fill="none" stroke="#fff"/>
+        </symbol>
+        <symbol id="crossmark" class="crossmark" viewBox="0 0 52 52" stroke-linecap="round" stroke-linejoin="round" stroke-width="6">
+            <circle cx="26" cy="26" r="26" fill="#ec644b"/>
+            <path d="M16 16 36 36 M36 16 16 36" fill="none" stroke="#fff"/>
+        </symbol>
+        </svg>
+    </span>
+
+    <div class="container">
+        <svg class="dbb-logo" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" class="dbb-logo" viewBox="0 0 512 512"><path d="M105.8 347.4v-82.9l67-28.8V106.6l66.6-29.1v212zm300.4.7v-82.8l-67-28.9V107.3l-66.6-28.9v211.8zm-150-29.6L123 376.7l133.1 57.8 133.6-58.1z" style="fill:#191919"/></svg>
+        <h1>BitBoxBridge</h1>
+        <p>{{ message }}</p>
+        <button class="decline" onclick="sendResponse(false)">
+            <svg><use xlink:href="#crossmark"></use></svg>
+            Reject
+        </button>
+        <button class="agree" onclick="sendResponse(true)">
+            <svg><use xlink:href="#checkmark"></use></svg>
+            Accept
+        </button>
+    </div>
     <script>
         function sendResponse(userChoice) {
             fetch(`/confirm/response/{{ counter }}/${userChoice}`, { method: 'POST' })

--- a/bitbox-bridge/resources/confirmation_dialog.html
+++ b/bitbox-bridge/resources/confirmation_dialog.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BitBoxBridge</title>
+</head>
+<body>
+    <h1>BitBoxBridge</h1>
+    <p>{{ message }}</p>
+    <button onclick="sendResponse(false)">Reject</button>
+    <button onclick="sendResponse(true)">Accept</button>
+    <script>
+        function sendResponse(userChoice) {
+            fetch(`/confirm/response/{{ counter }}/${userChoice}`, { method: 'POST' })
+                .then(() => window.close())
+                .catch(err => console.error('Error sending response:', err));
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Maintaining a whitelist in the binary does not scale and might put off
third party devs.

For a host that is not in the whitelist, we instead prompt the user if
they want to accept the connection.

Since we already run a server, we simply launch the browser on
confirmation page served by our server. It is a bit weird UX, but it
was the easiest solution I could find that works everywhere.

Alternatives considered:
- native dialogs using rfd - unfortunately does not work on macOS as
  the main process is windowless
- native dialogs using SDL: looks extremely ugly, hard to figure out deployment
- use Rust's Tauri or Qt or similar for native UIs: hard to deploy